### PR TITLE
fix: remove broken link from ZH how to contribute

### DIFF
--- a/_articles/zh-hant/how-to-contribute.md
+++ b/_articles/zh-hant/how-to-contribute.md
@@ -204,7 +204,6 @@ redirect_from: /zh-tw/how-to-contribute/
 
 * [GitHub 探索](https://github.com/explore/)
 * [First Timers Only](http://www.firsttimersonly.com/)
-* [你的第一個 PR](https://yourfirstpr.github.io/)
 * [CodeTriage](https://www.codetriage.com/)
 * [24 Pull Requests](https://24pullrequests.com/)
 * [Up For Grabs](http://up-for-grabs.net/)


### PR DESCRIPTION
- [x] Have you followed the [contributing guidelines](https://github.com/github/opensource.guide/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you explained what your changes do, and why they add value to the Guides?

**Please note: we will close your PR without comment if you do not check the boxes above and provide ALL requested information.**

-----

@CBID2 this solves the [CI issue](https://github.com/github/opensource.guide/actions/runs/6328240008/job/17185920557?pr=3098). This link was removed in all the translations except in ZH version.
